### PR TITLE
Made Servo a driver and fixed its AF mapping.

### DIFF
--- a/src/deck/drivers/src/bigquad.c
+++ b/src/deck/drivers/src/bigquad.c
@@ -53,7 +53,7 @@
 
 //Hardware configuration
 static bool isInit;
-static int8_t s_servo_angle = 0;
+//static int8_t s_servo_angle = 0;
 
 #ifdef CONFIG_DECK_BIGQUAD_ENABLE_OSD
 static MspObject s_MspObject;
@@ -84,7 +84,7 @@ static void bigquadInit(DeckInfo *info)
 
   DEBUG_PRINT("Switching to brushless.\n");
   motorsInit(motorMapBigQuadDeck);
-  extRxInit();
+//  extRxInit();
 
   // Ignore charging/charged state to allow low-battery warning.
   pmIgnoreChargedState(true);

--- a/src/drivers/src/motors_def.c
+++ b/src/drivers/src/motors_def.c
@@ -710,6 +710,28 @@ static const MotorPerifDef MOTORS_PA7_TIM14_CH1_BRUSHLESS_OD =
     .preloadConfig = TIM_OC1PreloadConfig,
 };
 
+// Deck MOSI, PA7, TIM14_CH1, Servo
+static const MotorPerifDef MOTORS_PA7_TIM14_CH1_SERVO =
+{
+    .drvType       = BRUSHLESS,
+    .gpioPerif     = RCC_AHB1Periph_GPIOA,
+    .gpioPort      = GPIOA,
+    .gpioPin       = GPIO_Pin_7,
+    .gpioPinSource = GPIO_PinSource7,
+    .gpioOType     = GPIO_OType_PP,
+    .gpioAF        = GPIO_AF_TIM14,
+    .timPerif      = RCC_APB1Periph_TIM14,
+    .tim           = TIM14,
+    .timPolarity   = TIM_OCPolarity_High,
+    .timDbgStop    = DBGMCU_TIM14_STOP,
+    .timPeriod     = MOTORS_BL_PWM_PERIOD,
+    .timPrescaler  = MOTORS_BL_PWM_PRESCALE,
+    .setCompare    = TIM_SetCompare1,
+    .getCompare    = TIM_GetCapture1,
+    .ocInit        = TIM_OC1Init,
+    .preloadConfig = TIM_OC1PreloadConfig,
+};
+
 /**
  * Mapping for Tags that don't have motors.
  * Actually same mapping as for CF2 but the pins are not physically connected.
@@ -808,4 +830,4 @@ const MotorPerifDef* motorMapCF21Brushless[NBR_OF_MOTORS] =
 /**
  * Servo mapped to the Bigquad CPPM (MOSI) port
  */
-const MotorPerifDef* servoMapMOSI = &MOTORS_PA7_TIM14_CH1_BRUSHLESS_OD;
+const MotorPerifDef* servoMapMOSI = &MOTORS_PA7_TIM14_CH1_SERVO;


### PR DESCRIPTION
This should fix the servo output problem but I couldn't test it properly. The main issue was that the pin source was not used.
`GPIO_PinAFConfig(servoMapMOSI->gpioPort, servoMapMOSI->gpioPinSource, servoMapMOSI->gpioAF);`

I also made the servo a driver. This you will have to activate in the menuconfig and enter forced driver as "bcServo". You should then get `DECK_INFO: compile-time forced driver bcServo added` in the console when you boot.